### PR TITLE
Zsh ize

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,23 @@ A collection of plugins for kubectl integration (for Kubectl versions >= 1.12.0)
 - All coding was written to maintain compatibility across both BSD and GNU.
 
 ## Install on Linux/Mac
+### bash
 ```bash
 git clone https://github.com/jordanwilson230/kubectl-plugins.git
 cd kubectl-plugins
 ./install-plugins.sh
 source ~/.bash_profile
 ```
+
+### Zsh
+```zsh
+git clone https://github.com/jordanwilson230/kubectl-plugins.git
+cd kubectl-plugins
+./install-plugins.sh
+source ~/.zshrc
+```
 #### To Uninstall
+##### bash
 ```
 rm -rf ~/.kube/plugins/jordanwilson230
 ex '+g/jordanwilson230/d' -cwq ~/.bash_profile
@@ -29,6 +39,21 @@ Remove the ```prompt``` plugin:
 ```
 ex '+g/function kubectl()/d' -cwq ~/.bash_profile
 ex '+g/KUBECTL_\(.*\)_PROMPT/d' -cwq ~/.bash_profile
+```
+
+##### Zsh
+```
+rm -rf ~/.kube/plugins/jordanwilson230
+ex '+g/jordanwilson230/d' -cwq ~/.zshrc
+```
+Remove the ```image``` plugin:
+```
+ex '+g/IMG_REGISTRY=/d' -cwq ~/.zshrc
+```
+Remove the ```prompt``` plugin:
+```
+ex '+g/function kubectl()/d' -cwq ~/.zshrc
+ex '+g/KUBECTL_\(.*\)_PROMPT/d' -cwq ~/.zshrc
 ```
 
 

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 
-case $SHELL in
-  *zsh* )
-    profile=.zshrc
-    ;;
-  * )
-    profile=.bash_profile
-    ;;
-esac
+profile=$(. ./which-shell.sh)
 
 echo "Detected shell: $SHELL"
 echo "Installing kubectl-plugins to ~/$profile"

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -1,17 +1,28 @@
 #!/bin/bash
 
+case $SHELL in
+  *zsh* )
+    profile=.zshrc
+    ;;
+  * )
+    profile=.bash_profile
+    ;;
+esac
+
+echo "Detected shell: $SHELL"
+echo "Installing kubectl-plugins to ~/$profile"
 
 # Move plugins and add location to path (required for kubectl 1.12+)
 chmod +x ./kubectl-*
 rm -rf ~/.kube/plugins/jordanwilson230
 mkdir -p ~/.kube/plugins/jordanwilson230
 cp -r ./kubectl-* ~/.kube/plugins/jordanwilson230/
-grep 'PATH=$PATH:~/.kube/plugins/jordanwilson230' ~/.bash_profile 1>/dev/null
-[ $? -ne 0 ] && echo 'export PATH=$PATH:~/.kube/plugins/jordanwilson230' >> ~/.bash_profile
+grep 'PATH=$PATH:~/.kube/plugins/jordanwilson230' ~/$profile 1>/dev/null
+[ $? -ne 0 ] && echo 'export PATH=$PATH:~/.kube/plugins/jordanwilson230' >> ~/$profile
 
 # Removes old installer function if exists
-ex '+g/function kubectl()/d' -cwq ~/.bash_profile >/dev/null 2>&1
+ex '+g/function kubectl()/d' -cwq ~/$profile >/dev/null 2>&1
 
 # Finished
-echo -e "\nDone.\nPlease open a new terminal or run: source ~/.bash_profile\n"
+echo -e "\nDone.\nPlease open a new terminal or run: source ~/$profile\n"
 kubectl plugin list --name-only | sed 's|-| |g'

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 
-profile=$(. ./which-shell.sh)
+SHELL_PROFILE=$(. ./which-shell.sh)
 
 echo "Detected shell: $SHELL"
-echo "Installing kubectl-plugins to ~/$profile"
+echo "Installing kubectl-plugins to ~/${SHELL_PROFILE}"
 
 # Move plugins and add location to path (required for kubectl 1.12+)
 chmod +x ./kubectl-*
 rm -rf ~/.kube/plugins/jordanwilson230
 mkdir -p ~/.kube/plugins/jordanwilson230
 cp -r ./kubectl-* ~/.kube/plugins/jordanwilson230/
-grep 'PATH=$PATH:~/.kube/plugins/jordanwilson230' ~/$profile 1>/dev/null
-[ $? -ne 0 ] && echo 'export PATH=$PATH:~/.kube/plugins/jordanwilson230' >> ~/$profile
+grep 'PATH=$PATH:~/.kube/plugins/jordanwilson230' ~/${SHELL_PROFILE} 1>/dev/null
+[ $? -ne 0 ] && echo 'export PATH=$PATH:~/.kube/plugins/jordanwilson230' >> ~/${SHELL_PROFILE}
 
 # Removes old installer function if exists
-ex '+g/function kubectl()/d' -cwq ~/$profile >/dev/null 2>&1
+ex '+g/function kubectl()/d' -cwq ~/${SHELL_PROFILE} >/dev/null 2>&1
 
 # Finished
-echo -e "\nDone.\nPlease open a new terminal or run: source ~/$profile\n"
+echo -e "\nDone.\nPlease open a new terminal or run: source ~/${SHELL_PROFILE}\n"
 kubectl plugin list --name-only | sed 's|-| |g'

--- a/kubectl-image
+++ b/kubectl-image
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+SHELL_PROFILE=$(. ./which-shell.sh)
 
 usage() { echo -e "Search for docker images.\nUsage: kubectl img <options> -i <image>" && grep " .)\ #" $0; exit 0; }
 [ $# -eq 0 ] && echo -e "\nERROR: Missing image name [-i].\n" && usage
@@ -15,9 +16,9 @@ while getopts ":i:cph" arg; do
       read -p "Save ${REGISTRY} for future reference? [y/n]: " save
       if [[ "$save" == "y" ]]; then
     # Overwrite or add default registry
-          ex '+g/IMG_REGISTRY=/d' -cwq ~/.bash_profile
-          echo 'export IMG_REGISTRY="'$REGISTRY'"' >> ~/.bash_profile
-          echo -e "\nSaved to ~/.bash_profile. Source or open a new terminal to take effect."
+          ex '+g/IMG_REGISTRY=/d' -cwq ~/${SHELL_PROFILE}
+          echo 'export IMG_REGISTRY="'$REGISTRY'"' >> ~/${SHELL_PROFILE}
+          echo -e "\nSaved to ~/${SHELL_PROFILE}. Source or open a new terminal to take effect."
       fi
       IMG_REGISTRY="$REGISTRY"
      ;;
@@ -58,7 +59,7 @@ if [[ "$IMAGE" ]]; then
           echo -e "\nSearching Docker Hub for $IMAGE."
           available_images=($(docker search --limit=25 "${REGISTRY}/$IMAGE" | sed -e 's|TAG||g; s|\[OK\]||g; s|AUTOMATED||g; s|OFFICIAL||g' | sed 's/[[:blank:]]*$//'))
           [ "${#available_images[@]}" -le 1 ] && echo -e "\nNo images found for $IMAGE.\n" && exit 1
-          count=0 
+          count=0
         ;;
     esac
 

--- a/kubectl-prompt
+++ b/kubectl-prompt
@@ -5,6 +5,7 @@ LBLUE=$(echo -en '\033[01;34m')
 YELLOW=$(echo -en '\033[00;33m')
 RESTORE=$(echo -en '\033[0m')
 
+SHELL_PROFILE=$(. ./which-shell.sh)
 
 COMMAND="${@}"
 export COMMAND="$COMMAND"
@@ -54,23 +55,23 @@ function add_prompt() {
     if [[ "$NAMESPACE" ]]; then
         read -p "${YELLOW}* Add the namespace ${NAMESPACE} to prompt list [y/n]? ${RESTORE}" answer
         [[ "$answer" != "y" ]] && exit 0
-        echo -e "\n${YELLOW}* Adding ${CLUSTER}${NAMESPACE} to \${KUBECTL_NAMESPACE_PROMPT} in ~/.bash_profile\n- The changes will be applied after starting a new terminal session or after running: source ~/.bash_profile ${RESTORE}"
+        echo -e "\n${YELLOW}* Adding ${CLUSTER}${NAMESPACE} to \${KUBECTL_NAMESPACE_PROMPT} in ~/${SHELL_PROFILE}\n- The changes will be applied after starting a new terminal session or after running: source ~/${SHELL_PROFILE} ${RESTORE}"
         KUBECTL_NAMESPACE_PROMPT="${KUBECTL_NAMESPACE_PROMPT[@]} ${NAMESPACE}"
-        ex '+g/KUBECTL_NAMESPACE_PROMPT=/d' -cwq ~/.bash_profile
-        echo "export KUBECTL_NAMESPACE_PROMPT=\"${KUBECTL_NAMESPACE_PROMPT}\"" >> ~/.bash_profile
+        ex '+g/KUBECTL_NAMESPACE_PROMPT=/d' -cwq ~/${SHELL_PROFILE}
+        echo "export KUBECTL_NAMESPACE_PROMPT=\"${KUBECTL_NAMESPACE_PROMPT}\"" >> ~/${SHELL_PROFILE}
     elif [[ "$CLUSTER" ]]; then
         read -p "${YELLOW}* Add the cluster ${CLUSTER} to prompt list [y/n]? ${RESTORE}" answer
         [[ "$answer" != "y" ]] && exit 0
-        echo -e "\n${YELLOW}* Adding ${CLUSTER} to \${KUBECTL_CLUSTER_PROMPT} in ~/.bash_profile\n- The changes will be applied after starting a new terminal session or after running: source ~/.bash_profile ${RESTORE}"
+        echo -e "\n${YELLOW}* Adding ${CLUSTER} to \${KUBECTL_CLUSTER_PROMPT} in ~/${SHELL_PROFILE}\n- The changes will be applied after starting a new terminal session or after running: source ~/${SHELL_PROFILE} ${RESTORE}"
         KUBECTL_CLUSTER_PROMPT+="${CLUSTER/%/ }"
-        ex '+g/KUBECTL_CLUSTER_PROMPT=/d' -cwq ~/.bash_profile
-        echo "export KUBECTL_CLUSTER_PROMPT=\"${KUBECTL_CLUSTER_PROMPT}\"" >> ~/.bash_profile
+        ex '+g/KUBECTL_CLUSTER_PROMPT=/d' -cwq ~/${SHELL_PROFILE}
+        echo "export KUBECTL_CLUSTER_PROMPT=\"${KUBECTL_CLUSTER_PROMPT}\"" >> ~/${SHELL_PROFILE}
     fi
 
     # Add function to check user context when kubectl is invoked.
     if [[ ! -z "$NAMESPACE" ]] || [[ ! -z "$CLUSTER" ]]; then
-        ex '+g/function kubectl/d' -cwq ~/.bash_profile
-        echo 'function kubectl() { command kubectl prompt "$@" && command kubectl "$@"' >> ~/.bash_profile
+        ex '+g/function kubectl/d' -cwq ~/${SHELL_PROFILE}
+        echo 'function kubectl() { command kubectl prompt "$@" && command kubectl "$@"' >> ~/${SHELL_PROFILE}
         exit 0
     fi
 }
@@ -79,9 +80,9 @@ function add_prompt() {
 
 ### Clear prompt list
 function remove_prompt() {
-    ex '+g/KUBECTL_NAMESPACE_PROMPT=/d' -cwq ~/.bash_profile
-    ex '+g/KUBECTL_CLUSTER_PROMPT=/d' -cwq ~/.bash_profile
-    ex '+g/function kubectl/d' -cwq ~/.bash_profile
+    ex '+g/KUBECTL_NAMESPACE_PROMPT=/d' -cwq ~/${SHELL_PROFILE}
+    ex '+g/KUBECTL_CLUSTER_PROMPT=/d' -cwq ~/${SHELL_PROFILE}
+    ex '+g/function kubectl/d' -cwq ~/${SHELL_PROFILE}
     echo -e "\nCleared prompt list.\nPlease open a new terminal for it to take affect.\n"
     exit 0
 }

--- a/kubectl-prompt
+++ b/kubectl-prompt
@@ -70,7 +70,7 @@ function add_prompt() {
     # Add function to check user context when kubectl is invoked.
     if [[ ! -z "$NAMESPACE" ]] || [[ ! -z "$CLUSTER" ]]; then
         ex '+g/function kubectl/d' -cwq ~/.bash_profile
-        echo 'function kubectl() { kube=$(which kubectl); $kube prompt "${@}" && command $kube "${@}" ; }' >> ~/.bash_profile
+        echo 'function kubectl() { command kubectl prompt "$@" && command kubectl "$@"' >> ~/.bash_profile
         exit 0
     fi
 }

--- a/kubectl-prompt
+++ b/kubectl-prompt
@@ -71,7 +71,7 @@ function add_prompt() {
     # Add function to check user context when kubectl is invoked.
     if [[ ! -z "$NAMESPACE" ]] || [[ ! -z "$CLUSTER" ]]; then
         ex '+g/function kubectl/d' -cwq ~/${SHELL_PROFILE}
-        echo 'function kubectl() { command kubectl prompt "$@" && command kubectl "$@"' >> ~/${SHELL_PROFILE}
+        echo 'function kubectl() { command kubectl prompt "$@" && command kubectl "$@" }' >> ~/${SHELL_PROFILE}
         exit 0
     fi
 }

--- a/which-shell.sh
+++ b/which-shell.sh
@@ -1,0 +1,8 @@
+case $SHELL in
+  *zsh* )
+    echo .zshrc
+    ;;
+  * )
+    echo .bash_profile
+    ;;
+esac


### PR DESCRIPTION
Branch off of https://github.com/jordanwilson230/kubectl-plugins/pull/10
Couldn't target branch in @jordanwilson230's repo and didn't want to make @grzesuav the middleman.

## Checklist

1) Addresses Issue: https://github.com/jordanwilson230/kubectl-plugins/issues/9
2) Instead of dependencies on the ~/.bash_profile throughout the code, the scripts can dynamically interpolate the shell profile. As of now support is Zsh and bash as the default.
3) Changes are GNU/BSD Compatible
4) Changes are applicable to the wider community.: I believe this is covered by the feature request.
5) Request help with testing if needed.
I tested against `prompt` and it's family of sub-commands and flags, as well as `image`.

